### PR TITLE
Add support for custom validation that uses ValidationContext.Items: …

### DIFF
--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/Child.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/Child.cs
@@ -15,6 +15,9 @@ namespace DataAnnotationsValidator.Tests
 
 		public IEnumerable<GrandChild> GrandChildren { get; set; } 
 
+		[SaveValidationContext]
+		public bool HasNoRealValidation { get; set; }
+
 		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
 		{
 			if (PropertyA.HasValue && PropertyB.HasValue && (PropertyA + PropertyB > 10))

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidator.Tests.csproj
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidator.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="GrandChild.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Parent.cs" />
+    <Compile Include="SaveValidationContextAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
@@ -116,7 +116,7 @@ namespace DataAnnotationsValidator.Tests
 		[Test]
 		public void TryValidateObjectRecursive_passes_validation_context_items_to_all_validation_calls()
 		{
-			var parent = new Parent();
+      var parent = new Parent();
 			parent.Child = new Child();
 			parent.Child.GrandChildren = new [] {new GrandChild()};
 			var validationResults = new List<ValidationResult>();
@@ -126,7 +126,7 @@ namespace DataAnnotationsValidator.Tests
 			_validator.TryValidateObjectRecursive(parent, validationResults, contextItems);
 
 			Assert.AreEqual(3, SaveValidationContextAttribute.SavedContexts.Count, "Test expects 3 validated properties in the object graph to have a SaveValidationContextAttribute");
-			Assert.That(SaveValidationContextAttribute.SavedContexts.Select(c => c.Items).All(items => items["key"] == contextItems["key"]));
+  Assert.That(SaveValidationContextAttribute.SavedContexts.Select(c => c.Items).All(items => items["key"] == contextItems["key"]));
 		}
 
 		[Test]

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
@@ -13,6 +13,7 @@ namespace DataAnnotationsValidator.Tests
 		[SetUp]
 		public void Setup()
 		{
+			SaveValidationContextAttribute.SavedContexts.Clear();
 			_validator = new DataAnnotationsValidator();
 		}
 
@@ -110,6 +111,22 @@ namespace DataAnnotationsValidator.Tests
 			Assert.AreEqual(2, validationResults.Count);
 			Assert.AreEqual(1, validationResults.ToList().Count(x => x.ErrorMessage == "GrandChild PropertyA not within range"));
 			Assert.AreEqual(1, validationResults.ToList().Count(x => x.ErrorMessage == "GrandChild PropertyB not within range"));
+		}
+
+		[Test]
+		public void TryValidateObjectRecursive_passes_validation_context_items_to_all_validation_calls()
+		{
+			var parent = new Parent();
+			parent.Child = new Child();
+			parent.Child.GrandChildren = new [] {new GrandChild()};
+			var validationResults = new List<ValidationResult>();
+
+			var contextItems = new Dictionary<object, object> {{"key", 12345}};
+
+			_validator.TryValidateObjectRecursive(parent, validationResults, contextItems);
+
+			Assert.AreEqual(3, SaveValidationContextAttribute.SavedContexts.Count, "Test expects 3 validated properties in the object graph to have a SaveValidationContextAttribute");
+			Assert.That(SaveValidationContextAttribute.SavedContexts.Select(c => c.Items).All(items => items["key"] == contextItems["key"]));
 		}
 
 		[Test]

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/GrandChild.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/GrandChild.cs
@@ -13,6 +13,9 @@ namespace DataAnnotationsValidator.Tests
 		[Range(0, 10, ErrorMessage = "GrandChild PropertyB not within range")]
 		public int? PropertyB { get; set; }
 
+		[SaveValidationContext]
+		public bool HasNoRealValidation { get; set; }
+
 		public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
 		{
 			if (PropertyA.HasValue && PropertyB.HasValue && (PropertyA + PropertyB > 10))

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/Parent.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/Parent.cs
@@ -18,6 +18,9 @@ namespace DataAnnotationsValidator.Tests
 		[SkipRecursiveValidation]
 		public Child SkippedChild { get; set; }
 
+		[SaveValidationContext]
+		public bool HasNoRealValidation { get; set; }
+
 		IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
 		{
 			if (PropertyA.HasValue && PropertyB.HasValue && (PropertyA + PropertyB > 10))

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/SaveValidationContextAttribute.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/SaveValidationContextAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace DataAnnotationsValidator.Tests
+{
+    public class SaveValidationContextAttribute: ValidationAttribute
+    {
+        public static IList<ValidationContext> SavedContexts = new List<ValidationContext>();
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            SavedContexts.Add(validationContext);
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/DataAnnotationsValidator/DataAnnotationsValidator/DataAnnotationsValidator.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator/DataAnnotationsValidator.cs
@@ -8,14 +8,14 @@ namespace DataAnnotationsValidator
 {
 	public class DataAnnotationsValidator : IDataAnnotationsValidator
 	{
-		public bool TryValidateObject(object obj, ICollection<ValidationResult> results)
+		public bool TryValidateObject(object obj, ICollection<ValidationResult> results, IDictionary<object, object> validationContextItems = null)
 		{
-			return Validator.TryValidateObject(obj, new ValidationContext(obj, null, null), results, true);
+			return Validator.TryValidateObject(obj, new ValidationContext(obj, null, validationContextItems), results, true);
 		}
 
-		public bool TryValidateObjectRecursive<T>(T obj, List<ValidationResult> results)
+		public bool TryValidateObjectRecursive<T>(T obj, List<ValidationResult> results, IDictionary<object, object> validationContextItems = null)
 		{
-			bool result = TryValidateObject(obj, results);
+			bool result = TryValidateObject(obj, results, validationContextItems);
 
             var properties = obj.GetType().GetProperties().Where(prop => prop.CanRead 
                 && !prop.GetCustomAttributes(typeof(SkipRecursiveValidation), false).Any() 
@@ -35,7 +35,7 @@ namespace DataAnnotationsValidator
 					foreach (var enumObj in asEnumerable)
 					{
 						var nestedResults = new List<ValidationResult>();
-						if (!TryValidateObjectRecursive(enumObj, nestedResults))
+						if (!TryValidateObjectRecursive(enumObj, nestedResults, validationContextItems))
 						{
 							result = false;
 							foreach (var validationResult in nestedResults)
@@ -49,7 +49,7 @@ namespace DataAnnotationsValidator
 				else
 				{
 					var nestedResults = new List<ValidationResult>();
-					if (!TryValidateObjectRecursive(value, nestedResults))
+					if (!TryValidateObjectRecursive(value, nestedResults, validationContextItems))
 					{
 						result = false;
 						foreach (var validationResult in nestedResults)

--- a/DataAnnotationsValidator/DataAnnotationsValidator/IDataAnnotationsValidator.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator/IDataAnnotationsValidator.cs
@@ -5,7 +5,7 @@ namespace DataAnnotationsValidator
 {
 	public interface IDataAnnotationsValidator
 	{
-		bool TryValidateObject(object obj, ICollection<ValidationResult> results);
-		bool TryValidateObjectRecursive<T>(T obj, List<ValidationResult> results);
+		bool TryValidateObject(object obj, ICollection<ValidationResult> results, IDictionary<object, object> validationContextItems = null);
+		bool TryValidateObjectRecursive<T>(T obj, List<ValidationResult> results, IDictionary<object, object> validationContextItems = null);
 	}
 }


### PR DESCRIPTION
I have a requirement for custom validation attributes that make use of `ValidationContext.Items`.  This PR allows an items dictionary to be passed in at the point of the initial call to `TryValidateObjectRecursive`; it is then passed through the recursive validation calls so it is available at each individual validation call.  

I have added a test that uses a custom attribute `SaveValidationContextAttribute` which records the ValidationContext that is passed to it when it validates.  The test uses the existing Parent, Child and GrandChild classes, to each of which I have added a new property that has no _real_ validation other than this attribute; enabling assertions against the passed context.