### PR TITLE
Added check for null enumeration value. 

### DIFF
--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/ClassWithNullableEnumeration.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/ClassWithNullableEnumeration.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace DataAnnotationsValidator.Tests
+{
+    public class ClassWithNullableEnumeration
+    {
+        public List<Child> Objects { get; set; }
+    }
+}

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidator.Tests.csproj
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidator.Tests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Child.cs" />
+    <Compile Include="ClassWithNullableEnumeration.cs" />
     <Compile Include="ClassWithDictionary.cs" />
     <Compile Include="DataAnnotationsValidatorTests.cs" />
     <Compile Include="GrandChild.cs" />

--- a/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator.Tests/DataAnnotationsValidatorTests.cs
@@ -204,5 +204,31 @@ namespace DataAnnotationsValidator.Tests
             Assert.IsTrue(result);
             Assert.IsEmpty(validationResults);
         }
+
+        [Test]
+        public void TryValidateObject_object_with_null_enumeration_values_does_not_fail()
+        {
+            var parent = new Parent { PropertyA = 1, PropertyB = 1 };
+            var classWithNullableEnumeration = new ClassWithNullableEnumeration
+            {
+                Objects = new List<Child>
+                {
+                    null,
+                    new Child
+                    {
+                        Parent = parent,
+                        PropertyA = 1,
+                        PropertyB = 2
+                    }
+                }
+            };
+            var validationResults = new List<ValidationResult>();
+
+            var result = _validator.TryValidateObjectRecursive(classWithNullableEnumeration, validationResults);
+
+            Assert.IsTrue(result);
+            Assert.IsEmpty(validationResults);
+        }
+ 
     }
 }

--- a/DataAnnotationsValidator/DataAnnotationsValidator/DataAnnotationsValidator.cs
+++ b/DataAnnotationsValidator/DataAnnotationsValidator/DataAnnotationsValidator.cs
@@ -46,16 +46,18 @@ namespace DataAnnotationsValidator
                 {
                     foreach (var enumObj in asEnumerable)
                     {
-                        var nestedResults = new List<ValidationResult>();
-                        if (!TryValidateObjectRecursive(enumObj, nestedResults, validatedObjects, validationContextItems))
-                        {
-                            result = false;
-                            foreach (var validationResult in nestedResults)
-                            {
-                                PropertyInfo property1 = property;
-                                results.Add(new ValidationResult(validationResult.ErrorMessage, validationResult.MemberNames.Select(x => property1.Name + '.' + x)));
-                            }
-                        };
+                        if ( enumObj != null) {
+                           var nestedResults = new List<ValidationResult>();
+                           if (!TryValidateObjectRecursive(enumObj, nestedResults, validatedObjects, validationContextItems))
+                           {
+                               result = false;
+                               foreach (var validationResult in nestedResults)
+                               {
+                                   PropertyInfo property1 = property;
+                                   results.Add(new ValidationResult(validationResult.ErrorMessage, validationResult.MemberNames.Select(x => property1.Name + '.' + x)));
+                               }
+                           };
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
I found an issue using the recursive validation with an enumeration.  I have a property that is array of nullable double values, and when there is a null value, it crashes attempting to validate the null.  This change will treat null values in an enumeration as valid.